### PR TITLE
Add Guava dependency to Spark 1.6.x pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,10 +27,10 @@
 			</exclusions>
 		</dependency>
 		<dependency>
-	        <groupId>com.google.guava</groupId>
-	        <artifactId>guava</artifactId>
-	        <version>19.0</version>
-        </dependency>
+        	        <groupId>com.google.guava</groupId>
+	                <artifactId>guava</artifactId>
+	                <version>19.0</version>
+                </dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,11 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<dependency>
+	        <groupId>com.google.guava</groupId>
+	        <artifactId>guava</artifactId>
+	        <version>19.0</version>
+        </dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
This package depends on jpmml-sparkml, which in turn depends on Spark for a Guava dependency. However, not all Spark 1.6.X versions and packaging contain Guava (in particular, the prebuilt tarballs available on [spark.apache.org/downloads.html](spark.apache.org/downloads.html) for Spark 1.6.{0,1,2,3} with Hadoop 2.6 do not). By adding the Guava dependency explicitly (as suggested by vruusmann in [Issue #5](https://github.com/jpmml/jpmml-sparkml-package/issues/5), one can assure oneself that this package will be built with Guava provided.